### PR TITLE
fix: set the dotnet directory for Uno-Check

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -140,6 +140,8 @@ jobs:
       # Secrets can't be referenced in conditionals, but environment variables can.
       # https://github.com/github/docs/issues/6861#issuecomment-870757186
       CODECOV_TOKEN: ${{ secrets.codecovToken }}
+      DOTNET_INSTALL_DIR: ${{ github.workspace }}\.dotnet
+      DOTNET_ROOT: ${{ github.workspace }}\.dotnet
 
     steps:
       - name: Checkout

--- a/.github/workflows/msbuild-build.yml
+++ b/.github/workflows/msbuild-build.yml
@@ -149,6 +149,8 @@ jobs:
       # Secrets can't be referenced in conditionals, but environment variables can.
       # https://github.com/github/docs/issues/6861#issuecomment-870757186
       CODECOV_TOKEN: ${{ secrets.codecovToken }}
+      DOTNET_INSTALL_DIR: ${{ github.workspace }}\.dotnet
+      DOTNET_ROOT: ${{ github.workspace }}\.dotnet
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Sets the DotNet Directory for the .NET install to fix Uno-Check