### PR TITLE
Use Uno Check 1.20.0-dev.7

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -35,7 +35,7 @@ on:
       uno-check-version:
         type: string
         description: The version of Uno Check to use.
-        default: 1.19.0
+        default: 1.20.0-dev.7
         required: false
       uno-check-manifest:
         type: string
@@ -153,9 +153,6 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: ${{ inputs.dotnet-version }}
-        env:
-          DOTNET_INSTALL_DIR: ${{ github.workspace }}\.dotnet
-          DOTNET_ROOT: ${{ github.workspace }}\.dotnet
 
       - name: Setup Windows SDK ${{ inputs.windows-sdk-version }}
         if: ${{ inputs.windows-sdk-version }}

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -140,8 +140,6 @@ jobs:
       # Secrets can't be referenced in conditionals, but environment variables can.
       # https://github.com/github/docs/issues/6861#issuecomment-870757186
       CODECOV_TOKEN: ${{ secrets.codecovToken }}
-      DOTNET_INSTALL_DIR: ${{ github.workspace }}\.dotnet
-      DOTNET_ROOT: ${{ github.workspace }}\.dotnet
 
     steps:
       - name: Checkout
@@ -151,9 +149,13 @@ jobs:
           submodules: ${{ inputs.submodules }}
 
       - name: Setup .NET ${{ inputs.dotnet-version }}
+        if: ${{ inputs.dotnet-version }}
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: ${{ inputs.dotnet-version }}
+        env:
+          DOTNET_INSTALL_DIR: ${{ github.workspace }}\.dotnet
+          DOTNET_ROOT: ${{ github.workspace }}\.dotnet
 
       - name: Setup Windows SDK ${{ inputs.windows-sdk-version }}
         if: ${{ inputs.windows-sdk-version }}

--- a/.github/workflows/msbuild-build.yml
+++ b/.github/workflows/msbuild-build.yml
@@ -35,7 +35,7 @@ on:
       uno-check-version:
         type: string
         description: The version of Uno Check to use.
-        default: 1.19.0
+        default: 1.20.0-dev.7
         required: false
       uno-check-manifest:
         type: string
@@ -162,9 +162,6 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: ${{ inputs.dotnet-version }}
-        env:
-          DOTNET_INSTALL_DIR: ${{ github.workspace }}\.dotnet
-          DOTNET_ROOT: ${{ github.workspace }}\.dotnet
 
       - name: Setup Windows SDK ${{ inputs.windows-sdk-version }}
         if: ${{ inputs.windows-sdk-version }}

--- a/.github/workflows/msbuild-build.yml
+++ b/.github/workflows/msbuild-build.yml
@@ -149,8 +149,6 @@ jobs:
       # Secrets can't be referenced in conditionals, but environment variables can.
       # https://github.com/github/docs/issues/6861#issuecomment-870757186
       CODECOV_TOKEN: ${{ secrets.codecovToken }}
-      DOTNET_INSTALL_DIR: ${{ github.workspace }}\.dotnet
-      DOTNET_ROOT: ${{ github.workspace }}\.dotnet
 
     steps:
       - name: Checkout
@@ -160,9 +158,13 @@ jobs:
           submodules: ${{ inputs.submodules }}
 
       - name: Setup .NET ${{ inputs.dotnet-version }}
+        if: ${{ inputs.dotnet-version }}
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: ${{ inputs.dotnet-version }}
+        env:
+          DOTNET_INSTALL_DIR: ${{ github.workspace }}\.dotnet
+          DOTNET_ROOT: ${{ github.workspace }}\.dotnet
 
       - name: Setup Windows SDK ${{ inputs.windows-sdk-version }}
         if: ${{ inputs.windows-sdk-version }}


### PR DESCRIPTION
# Description

Reverts environment variable for DOTNET_ROOT and uses new version of Uno Check which has updated logic for resolving workloads.